### PR TITLE
feat: converting error handing to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +127,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 name = "clean_git_history"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "clap",
  "git2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,7 @@ clap = { version = "4.4.6", features = ["derive"] }
 log = "0.4.20"
 pretty_env_logger = "0.5.0"
 
+# For error handling.
+anyhow = "1.0.89"
+
 git2 = { version = "0.19.0", default-features = false, features=[] }

--- a/end-to-end-tests/features/steps/assertions.py
+++ b/end-to-end-tests/features/steps/assertions.py
@@ -24,6 +24,12 @@ def assert_error_equals(result, error):
         f"Error          = {error.encode()}.\n"
 
 
+def assert_error_contains(result, error):
+    assert error in result.stderr, "Expected standard error to contain the error.\n" + \
+        f"Standard error = {result.stderr.encode()}.\n" + \
+        f"Error          = {error.encode()}.\n"
+
+
 def assert_error_matches_regex(result, regex):
     assert regex.match(result.stderr) is not None, f"Expected standard errors to match the regex.\n" + \
         f"Standard error = {result.stderr.encode()}.\n" + \

--- a/end-to-end-tests/features/steps/then.py
+++ b/end-to-end-tests/features/steps/then.py
@@ -30,25 +30,25 @@ def assert_git_history_is_not_clean(context):
 @then('their is a could not find commit hash "{commit_hash}" error.')
 def assert_could_not_find_commit_hash_error(context, commit_hash):
     # Given
-    could_not_find_commit_hash_error = f" ERROR clean_git_history::commits > Can not find a commit with the hash '{commit_hash}'.\n"  # fmt: off
+    could_not_find_commit_hash_error = f"Can not find a commit with the hash '{commit_hash}'.\n"  # fmt: off
 
     # When/Then
     result = assert_git_history_is_not_clean(context)
 
     # Then
-    assert_error_equals(result, could_not_find_commit_hash_error)
+    assert_error_contains(result, could_not_find_commit_hash_error)
 
 
 @then('their is a could not find reference "{reference}" error.')
 def assert_could_not_find_reference_error(context, reference):
     # Given
-    could_not_find_reference_error = f" ERROR clean_git_history::commits > Could not find a reference with the name \"{reference}\".\n"  # fmt: off
+    could_not_find_reference_error = f"Could not find a reference with the name \"{reference}\".\n"  # fmt: off
 
     # When/Then
     result = assert_git_history_is_not_clean(context)
 
     # Then
-    assert_error_equals(result, could_not_find_reference_error)
+    assert_error_contains(result, could_not_find_reference_error)
 
 
 @then(
@@ -56,13 +56,13 @@ def assert_could_not_find_reference_error(context, reference):
 def assert_could_not_find_shortened_commit_hash_error(
         context, shortened_commit_hash):
     # Given
-    could_not_find_shortened_commit_hash_error = f" ERROR clean_git_history::commits > No actual commit hashes start with the provided short commit hash \"{shortened_commit_hash}\".\n"  # fmt: off
+    could_not_find_shortened_commit_hash_error = f"No actual commit hashes start with the provided short commit hash \"{shortened_commit_hash}\".\n"  # fmt: off
 
     # When/Then
     result = assert_git_history_is_not_clean(context)
 
     # Then
-    assert_error_equals(result, could_not_find_shortened_commit_hash_error)
+    assert_error_contains(result, could_not_find_shortened_commit_hash_error)
 
 
 @then(
@@ -70,7 +70,7 @@ def assert_could_not_find_shortened_commit_hash_error(
 def assert_ambiguous_shortened_commit_hash_error(
         context, shortened_commit_hash):
     # Given
-    ambiguous_shortened_commit_hash_error = re.compile(f"^ ERROR clean_git_history::commits > Ambiguous short commit hash, the commit hashes [[]({shortened_commit_hash}[a-f0-9]*(, )?)*[]] all start with the provided short commit hash \"{shortened_commit_hash}\".\n$") # fmt: off
+    ambiguous_shortened_commit_hash_error = re.compile(f"^ ERROR clean_git_history > Unable to parse commits from the Git repository.\n\nCaused by:\n    Ambiguous short commit hash, the commit hashes [[]({shortened_commit_hash}[a-f0-9]+(, )?)+[]] all start with the provided short commit hash \"{shortened_commit_hash}\".\n$") # fmt: off
 
     # When/Then
     result = assert_git_history_is_not_clean(context)


### PR DESCRIPTION
Refactored end to end test error assertions to contains, because we now get the
full chain of error with context. So it is not as easy to assert on the entire
error message.