### PR TITLE
fix: reject 0 as an invalid --max-commits value

### DIFF
--- a/end-to-end-tests/features/max_commits.feature
+++ b/end-to-end-tests/features/max_commits.feature
@@ -1,4 +1,4 @@
-Feature: The maximum number of commits allowed, if exceeded will cause linting to fail. If set to 0 this check is disabled.
+Feature: The maximum number of commits allowed, if exceeded will cause linting to fail.
 
 
   Scenario Outline:
@@ -14,3 +14,15 @@ Feature: The maximum number of commits allowed, if exceeded will cause linting t
     Examples:
       | repository                                                | checkout_commit                          | commit_hash                              | max_commits |
       | https://github.com/DeveloperC286/zsh-simple-abbreviations | 2f6658245d0674d614687d62a53d9bae7aa9ac42 | a045cc7fff60f055908a16ed697a395256bc6c7d | 1           |
+
+
+  Scenario Outline: When the maximum number of commits is provided as 0 an invalid value error is returned.
+    Given the repository "<repository>" is cloned and checked out at the commit "<checkout_commit>".
+    When linting from the "<commit_hash>".
+    And the argument --max-commits is provided as "0".
+    Then their is an invalid max commits value "0" error.
+
+
+    Examples:
+      | repository                                                | checkout_commit                          | commit_hash                              |
+      | https://github.com/DeveloperC286/zsh-simple-abbreviations | 2f6658245d0674d614687d62a53d9bae7aa9ac42 | a045cc7fff60f055908a16ed697a395256bc6c7d |

--- a/end-to-end-tests/features/steps/then.py
+++ b/end-to-end-tests/features/steps/then.py
@@ -83,6 +83,18 @@ def assert_ambiguous_shortened_commit_hash_error(context, shortened_commit_hash)
     assert_error_matches_regex(result, ambiguous_shortened_commit_hash_error)
 
 
+@then('their is an invalid max commits value "{max_commits}" error.')
+def assert_invalid_max_commits_value_error(context, max_commits):
+    # Given
+    invalid_max_commits_value_error = f"error: invalid value '{max_commits}' for '--max-commits <MAX_COMMITS>'"  # fmt: off
+
+    # When/Then
+    result = assert_git_history_is_not_clean(context)
+
+    # Then
+    assert_error_contains(result, invalid_max_commits_value_error)
+
+
 @then('the GitHub Actions output contains a merge commit error.')
 def assert_github_output_contains_merge_commit_error(context):
     result = execute_clean_git_history(context)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ const ERROR_EXIT_CODE: i32 = 1;
 pub(crate) struct Arguments {
     #[arg(
         long,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
         help = "The maximum number of commits allowed, if exceeded will cause linting to fail."
     )]
     pub(crate) max_commits: Option<usize>,


### PR DESCRIPTION
The end-to-end feature documented that setting --max-commits to 0
disables the check, but the implementation treated 0 as a regular
limit, failing any non-empty commit range. Since omitting the flag
already means no limit, 0 has no meaning, so reject it at argument
parsing with a minimum value of 1 and cover the rejection with an
end-to-end scenario.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BMmt5puF81sHJeG3kPDSGo