### PR TITLE
refactor: use consistent short commit hash across output formats

### DIFF
--- a/src/commits/commit/mod.rs
+++ b/src/commits/commit/mod.rs
@@ -40,10 +40,6 @@ impl Commit {
         })
     }
 
-    /// Return a shortened, 7-character representation of the commit hash.
-    ///
-    /// Truncation is performed on `char` boundaries so it is safe for any
-    /// string, though git hashes are always hex and therefore ASCII.
     pub(crate) fn short_hash(&self) -> String {
         self.hash.chars().take(7).collect()
     }

--- a/src/commits/commit/mod.rs
+++ b/src/commits/commit/mod.rs
@@ -40,6 +40,14 @@ impl Commit {
         })
     }
 
+    /// Return a shortened, 7-character representation of the commit hash.
+    ///
+    /// Truncation is performed on `char` boundaries so it is safe for any
+    /// string, though git hashes are always hex and therefore ASCII.
+    pub(crate) fn short_hash(&self) -> String {
+        self.hash.chars().take(7).collect()
+    }
+
     pub(super) fn is_merge_commit(&self) -> bool {
         let is_merge_commit = self.number_of_parents > 1;
 

--- a/src/linting_results/github_actions.rs
+++ b/src/linting_results/github_actions.rs
@@ -8,7 +8,7 @@ pub(crate) fn print_all(results: &LintingResults) -> String {
     if let Some(commit_errors) = &results.commit_errors {
         for commit in &commit_errors.order {
             if let Some(errors) = commit_errors.errors.get(commit) {
-                let short_hash = &commit.hash[..7.min(commit.hash.len())];
+                let short_hash = commit.short_hash();
                 let message = commit.message.lines().next().unwrap_or_default();
 
                 let _ = writeln!(output, "::group::{short_hash} - {message}");

--- a/src/linting_results/pretty.rs
+++ b/src/linting_results/pretty.rs
@@ -12,7 +12,12 @@ pub(crate) fn print_all(results: &LintingResults) -> String {
     if let Some(commit_errors) = &results.commit_errors {
         for commit in &commit_errors.order {
             if let Some(errors) = commit_errors.errors.get(commit) {
-                let _ = writeln!(output, "{} - {}", red.paint("Commit Hash"), commit.hash);
+                let _ = writeln!(
+                    output,
+                    "{} - {}",
+                    red.paint("Commit Hash"),
+                    commit.short_hash()
+                );
                 let _ = writeln!(output, "{} - {:?}", red.paint("Message"), commit.message);
 
                 for error in errors {


### PR DESCRIPTION
Introduce a `Commit::short_hash()` helper that truncates the commit
hash to 7 characters on char boundaries, and use it in both the pretty
and GitHub Actions output formats.