### PR TITLE
refactor: set log level explicitly instead of mutating RUST_LOG

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,12 +48,20 @@ pub(crate) struct Arguments {
 fn main() {
     let arguments = Arguments::parse();
 
-    // Set up logging: if verbose is true and RUST_LOG is not set, default to info level
-    if arguments.verbose && std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
+    // Set up logging. RUST_LOG, if set, always takes precedence; otherwise
+    // --verbose defaults to the info level. Build the logger explicitly rather
+    // than mutating RUST_LOG so we don't rely on process-wide env var state.
+    let mut logger = pretty_env_logger::formatted_builder();
+    match std::env::var("RUST_LOG") {
+        Ok(rust_log) => {
+            logger.parse_filters(&rust_log);
+        }
+        Err(_) if arguments.verbose => {
+            logger.filter_level(log::LevelFilter::Info);
+        }
+        Err(_) => {}
     }
-
-    pretty_env_logger::init();
+    logger.init();
 
     info!("Version {}.", env!("CARGO_PKG_VERSION"));
     debug!("The command line arguments provided are {arguments:?}.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,9 @@ pub(crate) struct Arguments {
 fn main() {
     let arguments = Arguments::parse();
 
-    // Set up logging. RUST_LOG, if set, always takes precedence; otherwise
-    // --verbose defaults to the info level. Build the logger explicitly rather
-    // than mutating RUST_LOG so we don't rely on process-wide env var state.
+    // Set up logging. Log level precedence:
+    // - RUST_LOG, if set.
+    // - info, if --verbose is passed.
     let mut logger = pretty_env_logger::formatted_builder();
     match std::env::var("RUST_LOG") {
         Ok(rust_log) => {


### PR DESCRIPTION
std::env::set_var is unsafe in Rust 2024 and mutating a process-wide env
var before pretty_env_logger reads it is a footgun. Build the logger via
formatted_builder() instead.