### PR TITLE
refactor: log macro imports to edition 2021 style

### DIFF
--- a/src/commits/commit/mod.rs
+++ b/src/commits/commit/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use log::{debug, trace, warn};
 
 use crate::linting_results::CommitError;
 

--- a/src/commits/mod.rs
+++ b/src/commits/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 
 use anyhow::{bail, Context, Result};
 use git2::{Oid, Repository, Revwalk};
+use log::{debug, info, warn};
 
 use crate::linting_results::{
     CommitError, CommitErrors, CommitsError, CommitsErrors, LintingResults,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate log;
-extern crate pretty_env_logger;
-
 use anyhow::{Context, Result};
 use clap::Parser;
 use git2::Repository;
+use log::{debug, error, info};
 
 mod commits;
 mod linting_results;


### PR DESCRIPTION
Replace the edition-2015 `#[macro_use] extern crate log;` in main.rs
with per-module `use log::{...}` imports, bringing only the macros each
module actually uses into scope. Also drop the now-redundant
`extern crate pretty_env_logger;`, which is referenced by path.